### PR TITLE
Skip string.Format in Draw if window is not shown

### DIFF
--- a/NoSoliciting.Plugin/Interface/Settings.cs
+++ b/NoSoliciting.Plugin/Interface/Settings.cs
@@ -44,8 +44,12 @@ namespace NoSoliciting.Interface {
         }
 
         public void Draw() {
+            if (!this.ShowSettings) {
+                return;
+            }
+
             var windowTitle = string.Format(Language.Settings, Plugin.Name);
-            if (!this.ShowSettings || !ImGui.Begin($"{windowTitle}###NoSoliciting settings", ref this._showSettings)) {
+            if (!ImGui.Begin($"{windowTitle}###NoSoliciting settings", ref this._showSettings)) {
                 return;
             }
 


### PR DESCRIPTION
This is an extremely minor change but it lets us skip an allocation in Draw each frame, which reduces the draw overhead by about 70% when the plugin window is not shown.